### PR TITLE
Manifold RHS: add conservative volume + single-edge flux assembly, diagnostics, and constant-field regression test

### DIFF
--- a/cli/run_manifold_lsrk_convergence.py
+++ b/cli/run_manifold_lsrk_convergence.py
@@ -115,6 +115,8 @@ def main() -> None:
         default="upwind",
     )
     parser.add_argument("--alpha-lf", type=float, default=1.0)
+    parser.add_argument("--volume-form", choices=("split", "conservative"), default="split")
+    parser.add_argument("--surface-assembly", choices=("local_side", "single_edge"), default="local_side")
     parser.add_argument("--constant-value", type=float, default=1.0)
     parser.add_argument("--use-numba", action="store_true")
     args = parser.parse_args()
@@ -133,6 +135,8 @@ def main() -> None:
         field_case=args.field_case,
         flux_type=args.flux_type,
         alpha_lf=args.alpha_lf,
+        volume_form=args.volume_form,
+        surface_assembly=args.surface_assembly,
         constant_value=args.constant_value,
         record_history=True,
         verbose=True,

--- a/experiments/manifold_lsrk_convergence.py
+++ b/experiments/manifold_lsrk_convergence.py
@@ -43,6 +43,8 @@ _VALID_INITIAL_PRESETS = {
     "south_pole",
 }
 _VALID_FLUX_TYPES = {"upwind", "central", "lax_friedrichs"}
+_VALID_VOLUME_FORMS = {"split", "conservative"}
+_VALID_SURFACE_ASSEMBLIES = {"local_side", "single_edge"}
 
 
 @dataclass(frozen=True)
@@ -61,6 +63,8 @@ class ManifoldLSRKConvergenceConfig:
     constant_value: float = 1.0
     flux_type: str = "upwind"
     alpha_lf: float = 1.0
+    volume_form: str = "split"
+    surface_assembly: str = "local_side"
     use_numba: bool | None = True
     record_history: bool = False
     record_step_snapshots: bool = False
@@ -84,6 +88,8 @@ def _validate_config(config: ManifoldLSRKConvergenceConfig) -> None:
     if config.gaussian_width <= 0.0:
         raise ValueError("gaussian_width must be positive.")
     flux_type = _normalize_flux_type(config.flux_type)
+    volume_form = _normalize_volume_form(config.volume_form)
+    surface_assembly = _normalize_surface_assembly(config.surface_assembly)
     center_xyz = np.asarray(config.center_xyz, dtype=float).reshape(-1)
     if center_xyz.shape != (3,):
         raise ValueError("center_xyz must contain exactly three values.")
@@ -105,6 +111,8 @@ def _validate_config(config: ManifoldLSRKConvergenceConfig) -> None:
         raise ValueError("alpha_lf must be positive.")
     if flux_type == "lax_friedrichs" and config.alpha_lf < 1.0:
         raise ValueError("alpha_lf must be at least 1.0 for lax_friedrichs flux.")
+    if volume_form == "conservative" and surface_assembly == "local_side":
+        pass
     for t_snap in config.snapshot_times:
         if float(t_snap) < 0.0 or float(t_snap) > float(config.tf):
             raise ValueError("snapshot_times must satisfy 0 <= t <= tf.")
@@ -119,6 +127,20 @@ def _normalize_flux_type(flux_type: str) -> str:
     if flux not in _VALID_FLUX_TYPES:
         raise ValueError("flux_type must be one of: upwind, central, lax_friedrichs.")
     return flux
+
+
+def _normalize_volume_form(volume_form: str) -> str:
+    val = str(volume_form).strip().lower()
+    if val not in _VALID_VOLUME_FORMS:
+        raise ValueError("volume_form must be one of: split, conservative.")
+    return val
+
+
+def _normalize_surface_assembly(surface_assembly: str) -> str:
+    val = str(surface_assembly).strip().lower()
+    if val not in _VALID_SURFACE_ASSEMBLIES:
+        raise ValueError("surface_assembly must be one of: local_side, single_edge.")
+    return val
 
 
 def _normalize_snapshot_times(snapshot_times: tuple[float, ...]) -> tuple[float, ...]:
@@ -372,6 +394,8 @@ def _run_one_level(
             ref_ops=ref_ops,
             flux_type=_normalize_flux_type(config.flux_type),
             alpha_lf=config.alpha_lf,
+            volume_form=_normalize_volume_form(config.volume_form),
+            surface_assembly=_normalize_surface_assembly(config.surface_assembly),
             t=t,
             use_numba=config.use_numba,
         )

--- a/operators/manifold_rhs.py
+++ b/operators/manifold_rhs.py
@@ -7,7 +7,7 @@ import numpy as np
 from data.table1_rules import load_table1_rule
 from geometry.connectivity import build_face_connectivity
 from geometry.sphere_manifold_metrics import ManifoldGeometryCache
-from operators.exchange import evaluate_all_face_values, pair_face_traces
+from operators.exchange import evaluate_all_face_values, pair_face_traces, unique_interior_face_pairs
 from operators.sdg_flattened_divergence import build_table1_reference_diff_operators
 from operators.trace_policy import build_trace_policy
 from operators.vandermonde2d import vandermonde2d
@@ -19,7 +19,10 @@ try:
     prange = getattr(_numba, 'prange', range)
     _NUMBA_AVAILABLE = True
 except Exception:  # pragma: no cover
-    njit = lambda cache: lambda f: f
+    def njit(*args, **kwargs):
+        def _wrap(func):
+            return func
+        return _wrap
     prange = range
     _NUMBA_AVAILABLE = False
 
@@ -30,6 +33,8 @@ def _should_use_numba(use_numba: bool | None) -> bool:
 
 
 _VALID_FLUX_TYPES = {"upwind", "central", "lax_friedrichs"}
+_VALID_VOLUME_FORMS = {"split", "conservative"}
+_VALID_SURFACE_ASSEMBLIES = {"local_side", "single_edge"}
 
 
 def _normalize_flux_type(flux_type: str) -> str:
@@ -37,6 +42,20 @@ def _normalize_flux_type(flux_type: str) -> str:
     if flux not in _VALID_FLUX_TYPES:
         raise ValueError("flux_type must be 'upwind', 'central', or 'lax_friedrichs'.")
     return flux
+
+
+def _normalize_volume_form(volume_form: str) -> str:
+    form = str(volume_form).strip().lower()
+    if form not in _VALID_VOLUME_FORMS:
+        raise ValueError("volume_form must be 'split' or 'conservative'.")
+    return form
+
+
+def _normalize_surface_assembly(surface_assembly: str) -> str:
+    assembly = str(surface_assembly).strip().lower()
+    if assembly not in _VALID_SURFACE_ASSEMBLIES:
+        raise ValueError("surface_assembly must be 'local_side' or 'single_edge'.")
+    return assembly
 
 
 def _apply_reference_operator(D: np.ndarray, u: np.ndarray) -> np.ndarray:
@@ -390,6 +409,24 @@ def manifold_volume_divergence(
     return 0.5 * (term1 + term2 + term3)
 
 
+def manifold_volume_divergence_conservative(
+    q: np.ndarray,
+    geom: ManifoldGeometryCache,
+    U: np.ndarray,
+    V: np.ndarray,
+    W: np.ndarray,
+    Dr: np.ndarray,
+    Ds: np.ndarray,
+) -> np.ndarray:
+    q = np.asarray(q, dtype=float)
+    if q.shape != geom.X.shape:
+        raise ValueError("q must match geometry nodal shape.")
+    u_tilde, v_tilde = manifold_contravariant_velocity(geom, U, V, W)
+    Fr = geom.J * u_tilde * q
+    Fs = geom.J * v_tilde * q
+    return (_apply_reference_operator(Dr, Fr) + _apply_reference_operator(Ds, Fs)) / geom.J
+
+
 def manifold_surface_term(
     q: np.ndarray,
     geom: ManifoldGeometryCache,
@@ -596,6 +633,110 @@ def manifold_surface_term_from_exchange(
     return (ref_ops.lift @ surface_integral).T / geom.J
 
 
+def manifold_surface_term_single_edge(
+    q: np.ndarray,
+    geom: ManifoldGeometryCache,
+    velocity_xyz,
+    ref_ops: ManifoldReferenceOperators,
+    exchange_cache: ManifoldExchangeCache,
+    flux_type: str = "upwind",
+    alpha_lf: float = 1.0,
+    t: float = 0.0,
+    use_numba: bool | None = None,
+) -> np.ndarray:
+    q = np.asarray(q, dtype=float)
+    if q.shape != geom.X.shape:
+        raise ValueError("q must match geometry nodal shape.")
+    flux_type = _normalize_flux_type(flux_type)
+
+    if (
+        exchange_cache.J_face is not None
+        and exchange_cache.u_tilde_face is not None
+        and exchange_cache.v_tilde_face is not None
+    ):
+        J_face = exchange_cache.J_face
+        u_face = exchange_cache.u_tilde_face
+        v_face = exchange_cache.v_tilde_face
+    else:
+        U, V, W = _resolve_velocity_xyz(velocity_xyz, geom, t=t)
+        u_tilde, v_tilde = manifold_contravariant_velocity(geom, U, V, W)
+        J_face = _evaluate_face_values(geom.J, exchange_cache.trace, use_numba=use_numba)
+        u_face = _evaluate_face_values(u_tilde, exchange_cache.trace, use_numba=use_numba)
+        v_face = _evaluate_face_values(v_tilde, exchange_cache.trace, use_numba=use_numba)
+
+    q_face = _evaluate_face_values(q, exchange_cache.trace, use_numba=use_numba)
+    Fn_loc = (exchange_cache.nr * J_face * u_face + exchange_cache.ns * J_face * v_face) * q_face
+    Fhat_side, _ = manifold_single_edge_flux_sides(
+        q_face=q_face,
+        J_face=J_face,
+        u_face=u_face,
+        v_face=v_face,
+        exchange_cache=exchange_cache,
+        flux_type=flux_type,
+        alpha_lf=alpha_lf,
+    )
+    nfp = int(exchange_cache.trace["nfp"])
+    G = Fn_loc - Fhat_side
+    scaled = G * exchange_cache.face_weights
+    scaled_penalty = scaled.transpose(1, 2, 0).reshape(3 * nfp, q.shape[0])
+    surface_integral = ref_ops.face_extraction.T @ scaled_penalty
+    return (ref_ops.lift @ surface_integral).T / geom.J
+
+
+def manifold_single_edge_flux_sides(
+    q_face: np.ndarray,
+    J_face: np.ndarray,
+    u_face: np.ndarray,
+    v_face: np.ndarray,
+    exchange_cache: ManifoldExchangeCache,
+    flux_type: str = "upwind",
+    alpha_lf: float = 1.0,
+) -> tuple[np.ndarray, float]:
+    flux_type = _normalize_flux_type(flux_type)
+    Fhat_side = np.zeros_like(q_face)
+    EToE = np.asarray(exchange_cache.conn["EToE"], dtype=int)
+    EToF = np.asarray(exchange_cache.conn["EToF"], dtype=int)
+    face_flip = np.asarray(exchange_cache.conn["face_flip"], dtype=bool)
+    pairs = unique_interior_face_pairs(exchange_cache.conn)
+    edge_data: list[tuple[int, int, int, int, bool, np.ndarray, np.ndarray, np.ndarray]] = []
+    lf_speed = 0.0
+    for km, fm, kp, fp in pairs:
+        jm = fm - 1
+        jp = fp - 1
+        q_m = q_face[km, jm, :]
+        q_p = q_face[kp, jp, :]
+        a_m = J_face[km, jm, :] * (
+            exchange_cache.nr[km, jm, :] * u_face[km, jm, :]
+            + exchange_cache.ns[km, jm, :] * v_face[km, jm, :]
+        )
+        a_p = J_face[kp, jp, :] * (
+            exchange_cache.nr[kp, jp, :] * u_face[kp, jp, :]
+            + exchange_cache.ns[kp, jp, :] * v_face[kp, jp, :]
+        )
+        flip = bool(face_flip[km, jm])
+        if int(EToE[km, jm]) != kp or int(EToF[km, jm]) - 1 != jp:
+            raise ValueError("Connectivity mismatch while assembling single-edge manifold flux.")
+        if flip:
+            q_p = q_p[::-1]
+            a_p = a_p[::-1]
+        a_edge = 0.5 * (a_m - a_p)
+        lf_speed = max(lf_speed, float(np.max(np.abs(a_edge))))
+        edge_data.append((km, jm, kp, jp, flip, q_m, q_p, a_edge))
+
+    for km, jm, kp, jp, flip, q_m, q_p, a_edge in edge_data:
+        Fhat = 0.5 * a_edge * (q_m + q_p)
+        if flux_type == "upwind":
+            Fhat = Fhat - 0.5 * alpha_lf * np.abs(a_edge) * (q_p - q_m)
+        elif flux_type == "lax_friedrichs":
+            Fhat = Fhat - 0.5 * alpha_lf * lf_speed * (q_p - q_m)
+        Fhat_side[km, jm, :] = Fhat
+        if flip:
+            Fhat_side[kp, jp, ::-1] = -Fhat
+        else:
+            Fhat_side[kp, jp, :] = -Fhat
+    return Fhat_side, lf_speed
+
+
 def manifold_rhs(
     q: np.ndarray,
     geom: ManifoldGeometryCache,
@@ -640,6 +781,8 @@ def manifold_rhs_exchange(
     ref_ops: ManifoldReferenceOperators | None = None,
     flux_type: str = "upwind",
     alpha_lf: float = 1.0,
+    volume_form: str = "split",
+    surface_assembly: str = "local_side",
     t: float = 0.0,
     use_numba: bool | None = None,
 ) -> np.ndarray:
@@ -650,27 +793,33 @@ def manifold_rhs_exchange(
         ref_ops = build_manifold_table1_k4_reference_operators()
 
     U, V, W = _resolve_velocity_xyz(velocity_xyz, geom, t=t)
-    div = manifold_volume_divergence(
-        q=q,
-        geom=geom,
-        U=U,
-        V=V,
-        W=W,
-        Dr=ref_ops.Dr,
-        Ds=ref_ops.Ds,
-    )
-    surface = manifold_surface_term_from_exchange(
-        q=q,
-        geom=geom,
-        velocity_xyz=(U, V, W),
-        ref_ops=ref_ops,
-        exchange_cache=exchange_cache,
-        flux_type=flux_type,
-        alpha_lf=alpha_lf,
-        t=t,
-        use_numba=use_numba,
-    )
+    volume_form = _normalize_volume_form(volume_form)
+    surface_assembly = _normalize_surface_assembly(surface_assembly)
+    if volume_form == "split":
+        div = manifold_volume_divergence(
+            q=q, geom=geom, U=U, V=V, W=W, Dr=ref_ops.Dr, Ds=ref_ops.Ds, use_numba=use_numba
+        )
+    else:
+        div = manifold_volume_divergence_conservative(
+            q=q, geom=geom, U=U, V=V, W=W, Dr=ref_ops.Dr, Ds=ref_ops.Ds
+        )
+    if surface_assembly == "local_side":
+        surface = manifold_surface_term_from_exchange(
+            q=q, geom=geom, velocity_xyz=(U, V, W), ref_ops=ref_ops, exchange_cache=exchange_cache,
+            flux_type=flux_type, alpha_lf=alpha_lf, t=t, use_numba=use_numba
+        )
+    else:
+        surface = manifold_surface_term_single_edge(
+            q=q, geom=geom, velocity_xyz=(U, V, W), ref_ops=ref_ops, exchange_cache=exchange_cache,
+            flux_type=flux_type, alpha_lf=alpha_lf, t=t, use_numba=use_numba
+        )
     return -div + surface
+
+
+def manifold_rhs_mass_residual(rhs: np.ndarray, geom: ManifoldGeometryCache, weights: np.ndarray) -> float:
+    rhs = np.asarray(rhs, dtype=float)
+    w = np.asarray(weights, dtype=float).reshape(1, -1)
+    return float(np.sum(w * geom.J * rhs))
 
 
 def manifold_rhs_constant_field(

--- a/tests/test_manifold_lsrk.py
+++ b/tests/test_manifold_lsrk.py
@@ -12,10 +12,15 @@ from operators.manifold_rhs import (
     build_manifold_table1_k4_reference_operators,
     build_manifold_vmaps,
     manifold_rhs_exchange,
+    manifold_rhs_mass_residual,
+    manifold_single_edge_flux_sides,
+    manifold_surface_term_single_edge,
     manifold_surface_term,
     manifold_surface_term_from_exchange,
     pair_manifold_face_traces,
 )
+from operators.exchange import unique_interior_face_pairs
+from operators.exchange import evaluate_all_face_values
 from problems.sphere_advection import gaussian_bell_xyz, solid_body_velocity_xyz
 from experiments.manifold_lsrk_convergence import (
     ManifoldLSRKConvergenceConfig,
@@ -125,6 +130,91 @@ def test_constant_rhs_exchange_matches_free_stream_diagnostic():
 
     assert np.max(np.abs(surface)) < 1.0e-14
     assert np.all(np.isfinite(rhs))
+
+
+@pytest.mark.parametrize("n_div", [2, 4, 8])
+def test_constant_field_mass_rhs_residual_is_near_roundoff(n_div: int):
+    ref_ops, _, _, geom, U, V, W, cache = _fixture(n_div=n_div)
+    q = np.ones_like(geom.X)
+
+    rhs_old = manifold_rhs_exchange(
+        q,
+        geom,
+        (U, V, W),
+        cache,
+        ref_ops=ref_ops,
+        flux_type="upwind",
+        volume_form="split",
+        surface_assembly="local_side",
+        use_numba=False,
+    )
+    rhs_new = manifold_rhs_exchange(
+        q,
+        geom,
+        (U, V, W),
+        cache,
+        ref_ops=ref_ops,
+        flux_type="upwind",
+        volume_form="conservative",
+        surface_assembly="single_edge",
+        use_numba=False,
+    )
+
+    old_res = abs(manifold_rhs_mass_residual(rhs_old, geom, ref_ops.weights_2d))
+    new_res = abs(manifold_rhs_mass_residual(rhs_new, geom, ref_ops.weights_2d))
+
+    assert old_res < 1.0e-18
+    assert new_res < 1.0e-18
+
+
+@pytest.mark.parametrize("flux_type", ["central", "upwind"])
+def test_single_edge_flux_is_antisymmetric_on_interior_faces(flux_type: str):
+    ref_ops, _, _, geom, U, V, W, cache = _fixture(n_div=2)
+    q = np.random.default_rng(7).normal(size=geom.X.shape)
+    q_face = evaluate_all_face_values(q, cache.trace, use_numba=False)
+    Fhat_side, _ = manifold_single_edge_flux_sides(
+        q_face=q_face,
+        J_face=cache.J_face,
+        u_face=cache.u_tilde_face,
+        v_face=cache.v_tilde_face,
+        exchange_cache=cache,
+        flux_type=flux_type,
+        alpha_lf=1.0,
+    )
+    pairs = unique_interior_face_pairs(cache.conn)
+    for km, fm, kp, fp in pairs:
+        jm = fm - 1
+        jp = fp - 1
+        minus_side = Fhat_side[km, jm, :]
+        plus_side = Fhat_side[kp, jp, :]
+        if cache.conn["face_flip"][km, jm]:
+            plus_side = plus_side[::-1]
+        assert np.allclose(minus_side + plus_side, 0.0, atol=1.0e-13, rtol=0.0)
+
+    # also ensure the assembled single-edge surface term is finite
+    surface = manifold_surface_term_single_edge(
+        q, geom, (U, V, W), ref_ops, cache, flux_type=flux_type, use_numba=False
+    )
+    assert np.all(np.isfinite(surface))
+
+
+@pytest.mark.parametrize("flux_type", ["central", "upwind"])
+def test_mass_residual_improves_for_conservative_single_edge(flux_type: str):
+    ref_ops, _, _, geom, U, V, W, cache = _fixture(n_div=2)
+    q_const = np.ones_like(geom.X)
+    q_smooth = gaussian_bell_xyz(geom.X, geom.Y, geom.Z, R=1.0, center_xyz=(1.0, 0.0, 0.0))
+    for q in (q_const, q_smooth):
+        rhs_old = manifold_rhs_exchange(
+            q, geom, (U, V, W), cache, ref_ops=ref_ops, flux_type=flux_type,
+            volume_form="split", surface_assembly="local_side", use_numba=False
+        )
+        rhs_new = manifold_rhs_exchange(
+            q, geom, (U, V, W), cache, ref_ops=ref_ops, flux_type=flux_type,
+            volume_form="conservative", surface_assembly="single_edge", use_numba=False
+        )
+        old_res = abs(manifold_rhs_mass_residual(rhs_old, geom, ref_ops.weights_2d))
+        new_res = abs(manifold_rhs_mass_residual(rhs_new, geom, ref_ops.weights_2d))
+        assert new_res <= old_res + 1.0e-12
 
 
 def test_short_manifold_lsrk_errors_decrease_under_refinement():


### PR DESCRIPTION
### Motivation

- Provide an opt-in conservative volume form and a single-valued shared-edge numerical flux assembly for the manifold scalar-advection RHS to reduce global mass residuals and permit direct comparison with the existing split/local-side path.
- Expose runtime/CLI options and diagnostics so experiments and CI can select and verify the new conservative/single-edge path without changing default behavior.

### Description

- Added a conservative volume operator `manifold_volume_divergence_conservative(...)` and a single-edge surface assembly `manifold_surface_term_single_edge(...)` with the helper `manifold_single_edge_flux_sides(...)` that computes one common `Fhat` per unique interior face and writes antisymmetric contributions back to minus/plus sides with `face_flip` handling.
- Plumbed runtime selection into `manifold_rhs_exchange(...)` via new parameters `volume_form` ("split"|"conservative") and `surface_assembly` ("local_side"|"single_edge"), added normalizers and corresponding CLI flags `--volume-form` and `--surface-assembly`, and preserved the legacy default (`split` + `local_side`).
- Added a lightweight diagnostic `manifold_rhs_mass_residual(rhs, geom, weights)` to compute the global sum `sum_K sum_i weights_i * J_Ki * rhs_Ki` and added tests that assert antisymmetry of per-edge `Fhat` and compare mass-residuals between old and new paths.
- Added a regression test `test_constant_field_mass_rhs_residual_is_near_roundoff` that computes `rhs = manifold_rhs_exchange(...)` for `q=1` on meshes `n_div = 2, 4, 8` for both legacy and new paths and enforces near-roundoff global mass-RHS residuals.

### Testing

- Ran the targeted pytest selection for the new constant-field residual test: `PYTHONPATH=. pytest tests/test_manifold_lsrk.py -k "constant_field_mass_rhs_residual_is_near_roundoff" -q`, which reported `3 passed, 16 deselected`.
- Executed focused unit/integration checks for the new paths: the antisymmetry test `test_single_edge_flux_is_antisymmetric_on_interior_faces` and the mass-residual comparison `test_mass_residual_improves_for_conservative_single_edge` passed under `use_numba=False` and both `central`/`upwind` flux types in CI-targeted runs.
- Per-request diagnostics (ad-hoc Python runs) for `q=1` with `flux_type='upwind'` produced the following mass-RHS residuals (old vs new) and max-norm RHS values: `n_div=2: old 0.0 new 0.0 (max|rhs| old 4.56e-2 new 3.66e-1)`, `n_div=4: old 0.0 new 0.0 (max|rhs| old 1.46e-3 new 4.08e-2)`, `n_div=8: old -1.24e-23 new 2.75e-21 (max|rhs| old 4.67e-5 new 5.31e-3)`, showing global mass-RHS residuals near roundoff while the conservative+single-edge path yields larger pointwise RHS magnitudes in these cases.
- Note: an earlier LSRK time-integration comparison (separate experiment) showed larger integrated mass error for the conservative+single-edge path under the specific LSRK parameters used (reported in diagnostics), so time-stepping sensitivity remains and should be examined in broader parameter sweeps; the new tests make such regressions visible in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30ad587e88321940918c6896a5e52)